### PR TITLE
Fix missing apk issues due to python:3.8-alpine

### DIFF
--- a/docker/python/Dockerfile
+++ b/docker/python/Dockerfile
@@ -3,19 +3,32 @@ FROM python:3.8-alpine
 RUN apk update && \
   apk add \
   build-base \
+  cargo \
   curl \
-  git \
-  python-dev \
-  gettext \
   freetype-dev \
+  fribidi-dev \
+  gcc \
+  gettext \
+  git \
+  harfbuzz-dev \
+  lcms2-dev \
   libffi-dev \
-  openssl-dev \
+  libjpeg-turbo-dev \
+  libpng-dev \
+  libpq \
+  libressl-dev \
+  libwebp-dev \
   libxml2-dev \
   libxslt-dev \
-  libpq \
+  musl-dev \
+  npm \
+  openssl-dev \
   postgresql-client \
   postgresql-dev \
-  npm
+  python3-dev \
+  tcl-dev \
+  tk-dev \
+  zlib
 
 WORKDIR csskp
 


### PR DESCRIPTION
When deploying from scratch using docker errors related to cryptography, pillow and python-docx libraries are raised which prevents the deployment of the tool (see for example https://github.com/pyca/cryptography/issues/5771 and https://stackoverflow.com/questions/66118337/how-to-get-rid-of-cryptography-build-error). 
I have added the missing apk according to the documentation. This is related to the recent updates made and the use of python:3.8-alpine.